### PR TITLE
[server] 에러 핸들러 로직 수정

### DIFF
--- a/web/server/src/common/errorHandler.js
+++ b/web/server/src/common/errorHandler.js
@@ -1,28 +1,21 @@
 const createHttpError = require('http-errors');
 
 const errorMessages = {
-  VALIDATION_ERROR: 'Validation error',
   BAD_REQUEST: 'Bad request',
   NO_CONTENTS: 'No contents',
+  VALIDATION_ERROR: 'Validation error',
+};
+
+const errorStatus = {
+  [errorMessages.BAD_REQUEST]: 400,
+  [errorMessages.NO_CONTENTS]: 404,
+  [errorMessages.VALIDATION_ERROR]: 409,
 };
 
 const errorHandler = controller => async (req, res, next) =>
   await controller(req, res, next).catch(err => {
-    let status;
-    switch (err.message) {
-      case errorMessages.BAD_REQUEST:
-        status = 400;
-        break;
-      case errorMessages.NO_CONTENTS:
-        status = 404;
-        break;
-      case errorMessages.VALIDATION_ERROR:
-        status = 409;
-        break;
-      default:
-        status = 500;
-    }
-    next(createHttpError(status, err.message));
+    const status = errorStatus[err.message];
+    next(createHttpError(status || 500, err.message));
   });
 
 module.exports = {


### PR DESCRIPTION
- 기존: 핸들러 함수 안에서 switch-case 문으로 에러 메시지에 따라 status를 정해주었음.
- 문제: switch-case문 길이가 길고 가독성 측면에서도 좋지 않음
- 변경: switch-case 문 제거하고, 함수 외부 객체로 분리해 코드를 간결하게함