### PR TITLE
[server] 마일스톤 단건 조회 API 구현

### DIFF
--- a/web/server/src/controllers/milestones.js
+++ b/web/server/src/controllers/milestones.js
@@ -20,6 +20,15 @@ class MilestoneController {
     res.status(200).json(milestones);
   };
 
+  getOne = async (req, res) => {
+    const { num } = req.params;
+    const milestone = await this.milestoneService.findOneByNum({ num });
+    if (!milestone) {
+      throw new Error(NO_CONTENTS);
+    }
+    res.status(200).json(milestone);
+  };
+
   update = async (req, res) => {
     const {
       params: { num },

--- a/web/server/src/routes/milestones.js
+++ b/web/server/src/routes/milestones.js
@@ -5,6 +5,7 @@ const { errorHandler } = require('../common/errorHandler');
 
 router.post('', errorHandler(controller.add));
 router.get('', errorHandler(controller.getAll));
+router.get('/:num', errorHandler(controller.getOne));
 router.put('/:num', errorHandler(controller.update));
 router.delete('/:num', errorHandler(controller.delete));
 

--- a/web/server/src/services/milestones.js
+++ b/web/server/src/services/milestones.js
@@ -1,6 +1,16 @@
 const { Milestone, Issue, sequelize } = require('../db/models');
 const { countOpenedIssues, countClosedIssues } = require('../common/query');
 
+const option = {
+  attributes: {
+    include: [
+      [sequelize.literal(countOpenedIssues), 'openedIssues'],
+      [sequelize.literal(countClosedIssues), 'closedIssues'],
+    ],
+  },
+  group: ['num'],
+};
+
 class MilestoneService {
   constructor({ Milestone, Issue, sequelize }) {
     this.Milestone = Milestone;
@@ -11,27 +21,9 @@ class MilestoneService {
   add = ({ title, dueDate, description }) =>
     this.Milestone.create({ title, dueDate, description });
 
-  findAll = async () =>
-    this.Milestone.findAll({
-      attributes: {
-        include: [
-          [sequelize.literal(countOpenedIssues), 'openedIssues'],
-          [sequelize.literal(countClosedIssues), 'closedIssues'],
-        ],
-      },
-      group: ['num'],
-    });
+  findAll = async () => this.Milestone.findAll(option);
 
-  findOneByNum = async ({ num }) =>
-    this.Milestone.findByPk(num, {
-      attributes: {
-        include: [
-          [sequelize.literal(countOpenedIssues), 'openedIssues'],
-          [sequelize.literal(countClosedIssues), 'closedIssues'],
-        ],
-      },
-      group: ['num'],
-    });
+  findOneByNum = async ({ num }) => this.Milestone.findByPk(num, option);
 
   update = async ({ num, payload }) =>
     this.Milestone.update(payload, { where: { num } });

--- a/web/server/src/services/milestones.js
+++ b/web/server/src/services/milestones.js
@@ -22,6 +22,17 @@ class MilestoneService {
       group: ['num'],
     });
 
+  findOneByNum = async ({ num }) =>
+    this.Milestone.findByPk(num, {
+      attributes: {
+        include: [
+          [sequelize.literal(countOpenedIssues), 'openedIssues'],
+          [sequelize.literal(countClosedIssues), 'closedIssues'],
+        ],
+      },
+      group: ['num'],
+    });
+
   update = async ({ num, payload }) =>
     this.Milestone.update(payload, { where: { num } });
 


### PR DESCRIPTION
### * 추가
- routes/milestones : `GET /api/milestones/:num` 요청을 controller의 getOne() 함수로 처리
- controllers/milestones : service의 findOneByNum(num) 함수의 반환값으로 정상/오류를 응답
- services/milestones : model의 findByPk()를 이용해 데이터를 조회

### * 변경
- findAll()과 findOneByNum() 함수의 공통 로직인 option을 클래스 밖으로 분리

Close #110
Close #124 