### PR TITLE
[server] 이슈 전체 목록 조회 API

### DIFF
--- a/web/server/src/controllers/issues.js
+++ b/web/server/src/controllers/issues.js
@@ -5,7 +5,10 @@ class IssueController {
     this.issueService = issueService;
   }
 
-  getAll = async (req, res) => {};
+  getAll = async (req, res) => {
+    const issues = await this.issueService.findAll();
+    res.status(200).json(issues);
+  };
 
   getOne = async (req, res) => {};
 }

--- a/web/server/src/db/models/issue.js
+++ b/web/server/src/db/models/issue.js
@@ -38,24 +38,28 @@ module.exports = class Issue extends Model {
     Issue.hasMany(Comment, {
       foreignKey: 'issue_num',
       sourceKey: 'num',
+      as: 'comments',
     });
     Issue.belongsTo(Milestone, {
       foreignKey: 'milestone_num',
       targetKey: 'num',
+      as: 'milestone',
     });
     Issue.belongsTo(User, {
       foreignKey: 'user_num',
       targetKey: 'num',
+      as: 'author',
     });
     Issue.belongsToMany(User, {
-      as: 'assignee',
-      through: 'assignees',
       foreignKey: 'issue_num',
+      through: 'assignments',
+      as: 'assignees',
+      timestamps: false,
     });
     Issue.belongsToMany(Label, {
-      as: 'labeled',
-      through: 'issues_labels',
       foreignKey: 'issue_num',
+      through: 'issues_labels',
+      as: 'labels',
       timestamps: false,
     });
   }

--- a/web/server/src/services/issues.js
+++ b/web/server/src/services/issues.js
@@ -9,7 +9,48 @@ class IssueService {
     this.Comment = Comment;
   }
 
-  findAll = async () => {};
+  findAll = async () => {
+    const issues = await this.Issue.findAll({
+      attributes: ['num', 'title', 'createdAt', 'isClosed'],
+      where: {
+        isDeleted: false,
+        isClosed: false,
+      },
+      include: [
+        {
+          model: this.User,
+          as: 'author',
+          attributes: ['num', 'id'],
+        },
+        {
+          model: this.Milestone,
+          as: 'milestone',
+          attributes: ['num', 'title'],
+        },
+        {
+          model: this.Comment,
+          as: 'comments',
+          attributes: ['content'],
+          limit: 1,
+        },
+        {
+          model: this.Label,
+          as: 'labels',
+          attributes: ['num', 'name', 'color'],
+        },
+        {
+          model: this.User,
+          as: 'assignees',
+          attributes: ['num', 'id'],
+        },
+      ],
+    });
+    return issues.map(issue => {
+      issue.dataValues.comment = issue.dataValues.comments[0];
+      delete issue.dataValues.comments;
+      return issue;
+    });
+  };
 
   findOne = async () => {};
 }


### PR DESCRIPTION
- 컨트롤러와 서비스의 findAll() 구현
- GET query string을 이용한 필터는 적용 X
- 현재는 전체 목록을 불러올 뿐임
- 조인시 앨리어싱을 위해 모델의 약간의 수정