### PR TITLE
sequelize 모델 명을 소문자로 전환

### DIFF
--- a/web/server/src/common/query.js
+++ b/web/server/src/common/query.js
@@ -2,14 +2,14 @@ module.exports = {
   countOpenedIssues: `(
     SELECT COUNT(*)
     FROM issues
-    WHERE issues.milestone_num = Milestone.num
+    WHERE issues.milestone_num = milestone.num
       AND NOT issues.is_deleted
       AND NOT issues.is_closed
   )`,
   countClosedIssues: `(
     SELECT COUNT(*)
     FROM issues
-    WHERE issues.milestone_num = Milestone.num
+    WHERE issues.milestone_num = milestone.num
       AND NOT issues.is_deleted
       AND issues.is_closed
   )`,

--- a/web/server/src/db/models/comment.js
+++ b/web/server/src/db/models/comment.js
@@ -22,7 +22,7 @@ module.exports = class Comment extends Model {
       {
         sequelize,
         underscored: true,
-        modelName: 'Comment',
+        modelName: 'comment',
         tableName: 'comments',
         charset: 'utf8',
         collate: 'utf8_general_ci',

--- a/web/server/src/db/models/image.js
+++ b/web/server/src/db/models/image.js
@@ -21,7 +21,7 @@ module.exports = class Image extends Model {
         sequelize,
         underscored: true,
         timestamps: false,
-        modelName: 'Image',
+        modelName: 'image',
         tableName: 'images',
         charset: 'utf8',
         collate: 'utf8_general_ci',

--- a/web/server/src/db/models/issue.js
+++ b/web/server/src/db/models/issue.js
@@ -27,7 +27,7 @@ module.exports = class Issue extends Model {
       {
         sequelize,
         underscored: true,
-        modelName: 'Issue',
+        modelName: 'issue',
         tableName: 'issues',
         charset: 'utf8',
         collate: 'utf8_general_ci',

--- a/web/server/src/db/models/label.js
+++ b/web/server/src/db/models/label.js
@@ -25,7 +25,7 @@ module.exports = class Label extends Model {
         sequelize,
         timestamps: false,
         underscored: true,
-        modelName: 'Label',
+        modelName: 'label',
         tableName: 'labels',
         charset: 'utf8',
         collate: 'utf8_general_ci',

--- a/web/server/src/db/models/milestone.js
+++ b/web/server/src/db/models/milestone.js
@@ -24,7 +24,7 @@ module.exports = class Milestone extends Model {
         sequelize,
         timestamps: false,
         underscored: true,
-        modelName: 'Milestone',
+        modelName: 'milestone',
         tableName: 'milestones',
         charset: 'utf8',
         collate: 'utf8_general_ci',

--- a/web/server/src/db/models/oAuth.js
+++ b/web/server/src/db/models/oAuth.js
@@ -18,7 +18,7 @@ module.exports = class OAuth extends Model {
         sequelize,
         underscored: true,
         timestamps: false,
-        modelName: 'OAuth',
+        modelName: 'oauth',
         tableName: 'oauths',
         charset: 'utf8',
         collate: 'utf8_general_ci',

--- a/web/server/src/db/models/oAuthUser.js
+++ b/web/server/src/db/models/oAuthUser.js
@@ -17,7 +17,7 @@ module.exports = class OAuthUser extends Model {
         sequelize,
         underscored: true,
         timestamps: false,
-        modelName: 'OAuthUser',
+        modelName: 'oauthuser',
         tableName: 'oauths_users',
         charset: 'utf8',
         collate: 'utf8_general_ci',


### PR DESCRIPTION
서브 쿼리에서 참조하는 모델(테이블) 명과 
sequelize 모델을 설정할 때 옵션 값으로 지정한 모델 명 간 차이(대소문자)로 인해
발생하는 오류를 수정하기 위해서
모든 모델 명을 소문자로 전환

(수정 후 서버 테스트를 수행하여 정상적으로 작동하는 것을 확인)