### PR TITLE
이슈, 코멘트 API 구현 / 일부 외래키 설정 변경

### DIFF
--- a/web/server/src/controllers/comments.js
+++ b/web/server/src/controllers/comments.js
@@ -1,4 +1,5 @@
 const commentService = require('../services/comments');
+const { NO_CONTENTS } = require('../common/errorHandler');
 
 const commentController = {
   add: async (req, res) => {
@@ -8,7 +9,17 @@ const commentController = {
     res.status(200).json({ success: true });
   },
 
-  update: async (req, res) => {},
+  update: async (req, res) => {
+    const {
+      params: { num },
+      body: { content },
+    } = req;
+    const [updated] = await commentService.update({ num, content });
+    if (!updated) {
+      throw new Error(NO_CONTENTS);
+    }
+    res.status(200).json({ success: true });
+  },
 
   delete: async (req, res) => {},
 };

--- a/web/server/src/controllers/comments.js
+++ b/web/server/src/controllers/comments.js
@@ -2,7 +2,12 @@ const commentService = require('../services/comments');
 // const {} = require('../common/errorHandler');
 
 const commentController = {
-  add: async (req, res) => {},
+  add: async (req, res) => {
+    const { content, issueNum } = req.body;
+    const userNum = 1; // 인증 정보에서 userNum 값 빼오기
+    await commentService.add({ content, issueNum, userNum });
+    res.status(200).json({ success: true });
+  },
 
   update: async (req, res) => {},
 

--- a/web/server/src/controllers/comments.js
+++ b/web/server/src/controllers/comments.js
@@ -1,5 +1,4 @@
 const commentService = require('../services/comments');
-// const {} = require('../common/errorHandler');
 
 const commentController = {
   add: async (req, res) => {

--- a/web/server/src/controllers/issues.js
+++ b/web/server/src/controllers/issues.js
@@ -27,13 +27,11 @@ const issueController = {
     }
     const issue = await issueService.add({ title, userNum, milestoneNum });
     await commentService.add({ content, userNum, issueNum: issue.num });
-    labels.forEach(
-      async labelNum =>
-        await labelingService.add({ issueNum: issue.num, labelNum }),
+    labels.forEach(labelNum =>
+      labelingService.add({ issueNum: issue.num, labelNum }),
     );
-    assignees.forEach(
-      async userNum =>
-        await assignmentService.add({ issueNum: issue.num, userNum }),
+    assignees.forEach(userNum =>
+      assignmentService.add({ issueNum: issue.num, userNum }),
     );
     res.status(200).json({ success: true });
   },

--- a/web/server/src/controllers/issues.js
+++ b/web/server/src/controllers/issues.js
@@ -1,5 +1,6 @@
 const issueService = require('../services/issues');
-const { NO_CONTENTS } = require('../common/errorHandler');
+const commentService = require('../services/comments');
+const { NO_CONTENTS, BAD_REQUEST } = require('../common/errorHandler');
 
 const issueController = {
   getAll: async (req, res) => {
@@ -14,6 +15,19 @@ const issueController = {
       throw new Error(NO_CONTENTS);
     }
     res.status(200).json(issue);
+  },
+
+  add: async (req, res) => {
+    const { title, content, assignees, labels, milestoneNum } = req.body;
+    const userNum = 1; // 인증 정보에서 userNum 값 빼오기
+    if (!content) {
+      throw new Error(BAD_REQUEST);
+    }
+    const issue = await issueService.add({ title, userNum, milestoneNum });
+    await commentService.add({ content, userNum, issueNum: issue.num });
+    // assignees 피봇 테이블에 등록
+    // labeling 피봇 테이블에 등록
+    res.status(200).json({ success: true });
   },
 };
 

--- a/web/server/src/db/models/comment.js
+++ b/web/server/src/db/models/comment.js
@@ -31,11 +31,17 @@ module.exports = class Comment extends Model {
   }
   static associate({ Comment, Issue, User }) {
     Comment.belongsTo(Issue, {
-      foreignKey: 'issue_num',
+      foreignKey: {
+        name: 'issue_num',
+        allowNull: false,
+      },
       targetKey: 'num',
     });
     Comment.belongsTo(User, {
-      foreignKey: 'user_num',
+      foreignKey: {
+        name: 'user_num',
+        allowNull: false,
+      },
       targetKey: 'num',
       as: 'writer',
     });

--- a/web/server/src/db/models/comment.js
+++ b/web/server/src/db/models/comment.js
@@ -32,14 +32,14 @@ module.exports = class Comment extends Model {
   static associate({ Comment, Issue, User }) {
     Comment.belongsTo(Issue, {
       foreignKey: {
-        name: 'issue_num',
+        name: 'issueNum',
         allowNull: false,
       },
       targetKey: 'num',
     });
     Comment.belongsTo(User, {
       foreignKey: {
-        name: 'user_num',
+        name: 'userNum',
         allowNull: false,
       },
       targetKey: 'num',

--- a/web/server/src/db/models/issue.js
+++ b/web/server/src/db/models/issue.js
@@ -37,19 +37,19 @@ module.exports = class Issue extends Model {
   static associate({ Issue, Comment, Milestone, User, Label }) {
     Issue.hasMany(Comment, {
       foreignKey: {
-        name: 'issue_num',
+        name: 'issueNum',
         allowNull: false,
       },
       sourceKey: 'num',
       as: 'comments',
     });
     Issue.belongsTo(Milestone, {
-      foreignKey: 'milestone_num',
+      foreignKey: 'milestoneNum',
       targetKey: 'num',
     });
     Issue.belongsTo(User, {
       foreignKey: {
-        name: 'user_num',
+        name: 'userNum',
         allowNull: false,
       },
       targetKey: 'num',

--- a/web/server/src/db/models/issue.js
+++ b/web/server/src/db/models/issue.js
@@ -36,7 +36,10 @@ module.exports = class Issue extends Model {
   }
   static associate({ Issue, Comment, Milestone, User, Label }) {
     Issue.hasMany(Comment, {
-      foreignKey: 'issue_num',
+      foreignKey: {
+        name: 'issue_num',
+        allowNull: false,
+      },
       sourceKey: 'num',
       as: 'comments',
     });

--- a/web/server/src/db/models/issue.js
+++ b/web/server/src/db/models/issue.js
@@ -48,7 +48,10 @@ module.exports = class Issue extends Model {
       targetKey: 'num',
     });
     Issue.belongsTo(User, {
-      foreignKey: 'user_num',
+      foreignKey: {
+        name: 'user_num',
+        allowNull: false,
+      },
       targetKey: 'num',
       as: 'author',
     });

--- a/web/server/src/db/models/milestone.js
+++ b/web/server/src/db/models/milestone.js
@@ -38,7 +38,7 @@ module.exports = class Milestone extends Model {
   }
   static associate({ Milestone, Issue }) {
     Milestone.hasMany(Issue, {
-      foreignKey: 'milestone_num',
+      foreignKey: 'milestoneNum',
       sourceKey: 'num',
     });
   }

--- a/web/server/src/db/models/user.js
+++ b/web/server/src/db/models/user.js
@@ -34,12 +34,19 @@ module.exports = class User extends Model {
     );
   }
   static associate({ User, OAuthUser, Comment, Issue }) {
-    [OAuthUser, Issue, Comment].forEach(model =>
+    [OAuthUser, Issue].forEach(model =>
       User.hasMany(model, {
         foreignKey: 'user_num',
         sourceKey: 'num',
       }),
     );
+    User.hasMany(Comment, {
+      foreignKey: {
+        name: 'user_num',
+        allowNull: false,
+      },
+      sourceKey: 'num',
+    });
     User.belongsToMany(Issue, {
       foreignKey: 'user_num',
       through: 'assignments',

--- a/web/server/src/db/models/user.js
+++ b/web/server/src/db/models/user.js
@@ -34,17 +34,17 @@ module.exports = class User extends Model {
     );
   }
   static associate({ User, OAuthUser, Comment, Issue }) {
-    [OAuthUser, Issue].forEach(model =>
+    [Issue, Comment].forEach(model =>
       User.hasMany(model, {
-        foreignKey: 'user_num',
+        foreignKey: {
+          name: 'user_num',
+          allowNull: false,
+        },
         sourceKey: 'num',
       }),
     );
-    User.hasMany(Comment, {
-      foreignKey: {
-        name: 'user_num',
-        allowNull: false,
-      },
+    User.hasMany(OAuthUser, {
+      foreignKey: 'user_num',
       sourceKey: 'num',
     });
     User.belongsToMany(Issue, {

--- a/web/server/src/db/models/user.js
+++ b/web/server/src/db/models/user.js
@@ -37,7 +37,7 @@ module.exports = class User extends Model {
     [Issue, Comment].forEach(model =>
       User.hasMany(model, {
         foreignKey: {
-          name: 'user_num',
+          name: 'userNum',
           allowNull: false,
         },
         sourceKey: 'num',

--- a/web/server/src/routes/issues.js
+++ b/web/server/src/routes/issues.js
@@ -5,5 +5,6 @@ const { errorHandler } = require('../common/errorHandler');
 
 router.get('', errorHandler(controller.getAll));
 router.get('/:num', errorHandler(controller.getOne));
+router.post('', errorHandler(controller.add));
 
 module.exports = router;

--- a/web/server/src/services/comments.js
+++ b/web/server/src/services/comments.js
@@ -1,9 +1,10 @@
-const { sequelize, Comment, Issue, User } = require('../db/models');
+const { Comment } = require('../db/models');
 
 const commentService = {
   add: async ({ content, userNum, issueNum }) =>
     Comment.create({ content, user_num: userNum, issue_num: issueNum }),
-  update: async (req, res) => {},
+  update: async ({ num, content }) =>
+    Comment.update({ content }, { where: { num } }),
 
   delete: async (req, res) => {},
 };

--- a/web/server/src/services/comments.js
+++ b/web/server/src/services/comments.js
@@ -2,7 +2,7 @@ const { Comment } = require('../db/models');
 
 const commentService = {
   add: async ({ content, userNum, issueNum }) =>
-    Comment.create({ content, user_num: userNum, issue_num: issueNum }),
+    Comment.create({ content, userNum, issueNum }),
   update: async ({ num, content }) =>
     Comment.update({ content }, { where: { num } }),
 

--- a/web/server/src/services/comments.js
+++ b/web/server/src/services/comments.js
@@ -1,8 +1,8 @@
 const { sequelize, Comment, Issue, User } = require('../db/models');
 
 const commentService = {
-  add: async (req, res) => {},
-
+  add: async ({ content, userNum, issueNum }) =>
+    Comment.create({ content, user_num: userNum, issue_num: issueNum }),
   update: async (req, res) => {},
 
   delete: async (req, res) => {},

--- a/web/server/src/services/issues.js
+++ b/web/server/src/services/issues.js
@@ -96,7 +96,7 @@ const issueService = {
       ],
     }),
   add: async ({ title, userNum, milestoneNum }) =>
-    Issue.create({ title, user_num: userNum, milestone_num: milestoneNum }),
+    Issue.create({ title, userNum, milestoneNum }),
 };
 
 module.exports = issueService;

--- a/web/server/src/services/issues.js
+++ b/web/server/src/services/issues.js
@@ -95,6 +95,8 @@ const issueService = {
         },
       ],
     }),
+  add: async ({ title, userNum, milestoneNum }) =>
+    Issue.create({ title, user_num: userNum, milestone_num: milestoneNum }),
 };
 
 module.exports = issueService;


### PR DESCRIPTION
### 코멘트 API
- 추가 API 구현: userNum은 인증정보에서 가져오게 수정되어야 함
- 수정 API 구현

### 이슈 API
- 추가 API 구현
  - 이슈등록 > 코멘트등록 > 어싸이니등록 > 레이블등록 순으로 진행
  - userNum은 인증정보에서 가져오게 수정되어야 함
  - Labeling과 Assignees 등록은 서비스가 나오면 붙이는 작업 요구

### 모델 외래키 Not Null
- 유저 - 이슈
- 유저 - 코멘트
- 이슈 - 코멘트

### 일부 외래키명을 카멜케이스로 변경
- 코멘트, 이슈, 마일스톤, 유저