### PR TITLE
issue 전체 조회 시 생성 순서의 역으로 정렬하도록 order 옵션 추가

### DIFF
--- a/web/server/src/services/issues.js
+++ b/web/server/src/services/issues.js
@@ -16,6 +16,7 @@ const issueService = {
         isDeleted: false,
         isClosed,
       },
+      order: [['num', 'DESC']],
       include: [
         {
           model: User,


### PR DESCRIPTION
issue 전체 조회 시 생성 순서의 역으로 정렬하도록 `order` 옵션 추가

Close #211 