### PR TITLE
OAuth 인증 후 access token 을 사용하는 회원 가입 로직 분리

### DIFF
--- a/web/server/src/controllers/auths.js
+++ b/web/server/src/controllers/auths.js
@@ -1,7 +1,5 @@
 const authService = require('../services/auths');
-const userService = require('../services/users');
 const oAuthService = require('../services/oAuths');
-const authorizationService = require('../services/authorization');
 const jwt = require('../common/jwt');
 
 const authController = {
@@ -18,20 +16,8 @@ const authController = {
 
     const oAuth = await oAuthService.findOne({ service });
     let [user] = await oAuth.getUsers({ accessToken });
-
-    if (!user) {
-      const userData = await authService.getUserDataByAccessToken({
-        service,
-        accessToken,
-      });
-
-      user = await userService.join({ ...userData, password: accessToken });
-      await authorizationService.add({
-        userNum: user.num,
-        oAuthNum: oAuth.num,
-        accessToken,
-      });
-    }
+    user =
+      user || (await authService.joinUserByAccessToken({ oAuth, accessToken }));
 
     const token = await jwt.sign(user);
     res.cookie('token', token);

--- a/web/server/src/services/auths.js
+++ b/web/server/src/services/auths.js
@@ -1,5 +1,8 @@
 const axios = require('axios');
 
+const userService = require('../services/users');
+const authorizationService = require('../services/authorization');
+
 const config = {
   gitHub: {
     codeUrl: 'https://github.com/login/oauth/authorize',
@@ -54,6 +57,22 @@ const authService = {
     const iOSSchema = process.env.IOS_APP_SCHEMA;
     const webDomain = process.env.WEB_DOMAIN;
     return isMobile ? `${iOSSchema}?token=${token}` : webDomain;
+  },
+
+  joinUserByAccessToken: async ({ oAuth, accessToken }) => {
+    const userData = await authService.getUserDataByAccessToken({
+      service: oAuth.name,
+      accessToken,
+    });
+
+    const user = await userService.join({ ...userData, password: accessToken });
+    await authorizationService.add({
+      userNum: user.num,
+      oAuthNum: oAuth.num,
+      accessToken,
+    });
+
+    return user;
   },
 };
 


### PR DESCRIPTION
OAuth 인증 후 access token 을 사용하는 회원 가입 로직을 서비스 레이어에서 제공하도록 분리